### PR TITLE
Add support for --separate and fix handling of empty files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.5'
+version = '0.1.6'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/svinst/defchk.py
+++ b/svinst/defchk.py
@@ -7,7 +7,7 @@ import sys
 def is_single_file(files):
     return isinstance(files, (str, Path))
 
-def call_svinst(files, includes=None, defines=None, ignore_include=False, full_tree=False):
+def call_svinst(files, includes=None, defines=None, ignore_include=False, full_tree=False, separate=False):
     # set defaults
     if includes is None:
         includes = []
@@ -32,6 +32,8 @@ def call_svinst(files, includes=None, defines=None, ignore_include=False, full_t
         args += ['--ignore-include']
     if full_tree:
         args += ['--full-tree']
+    if separate:
+        args += ['--separate']
 
     # convert arguments to strings
     args = [str(elem) for elem in args]
@@ -106,6 +108,9 @@ class PkgInst(Inst):
 def process_defs(result):
     retval = []
 
+    if result is None:
+        result = []
+
     for entry in result:
         if 'pkg_name' in entry:
             def_ = PkgDef(name=entry['pkg_name'])
@@ -129,11 +134,11 @@ def process_defs(result):
 
     return retval
 
-def get_defs(files, includes=None, defines=None, ignore_include=False):
+def get_defs(files, includes=None, defines=None, ignore_include=False, separate=False):
     single = is_single_file(files)
 
     out = call_svinst(files=files, includes=includes, defines=defines,
-                      ignore_include=ignore_include, full_tree=False)
+                      ignore_include=ignore_include, separate=separate, full_tree=False)
 
     retval = [process_defs(elem['defs']) for elem in out['files']]
 
@@ -209,11 +214,11 @@ def process_syntax_tree(result):
             )
     return retval
 
-def get_syntax_tree(files, includes=None, defines=None, ignore_include=False):
+def get_syntax_tree(files, includes=None, defines=None, ignore_include=False, separate=False):
     single = is_single_file(files)
 
     out = call_svinst(files=files, includes=includes, defines=defines,
-                      ignore_include=ignore_include, full_tree=True)
+                      ignore_include=ignore_include, separate=separate, full_tree=True)
 
     retval = [process_syntax_tree(elem['syntax_tree']) for elem in out['files']]
 

--- a/tests/test_svinst.py
+++ b/tests/test_svinst.py
@@ -114,3 +114,23 @@ def test_intf():
         IntfDef("d")
     ]
     assert result == expct
+
+def test_empty():
+    result = get_defs(VLOG_DIR / 'empty.sv')
+    expct = []
+    assert result == expct
+
+def test_multi():
+    result = get_defs([
+        VLOG_DIR / 'multi' / 'define1.v',
+        VLOG_DIR / 'multi' / 'test1.sv',
+        VLOG_DIR / 'multi' / 'define2.v',
+        VLOG_DIR / 'multi' / 'dut.v'
+    ])
+    expct = [
+        [],
+        [ModDef("test", [ModInst("dut", "u0")])],
+        [],
+        [ModDef("dut")]
+    ]
+    assert result == expct

--- a/tests/verilog/multi/define1.v
+++ b/tests/verilog/multi/define1.v
@@ -1,0 +1,1 @@
+`define WIDTH 16

--- a/tests/verilog/multi/define2.v
+++ b/tests/verilog/multi/define2.v
@@ -1,0 +1,2 @@
+`undef WIDTH
+`define WIDTH 32

--- a/tests/verilog/multi/dut.v
+++ b/tests/verilog/multi/dut.v
@@ -1,0 +1,9 @@
+module dut(input clk);
+
+reg [`WIDTH-1:0] cnt;
+
+always @(posedge clk) begin
+cnt <= cnt + 1;
+end
+
+endmodule

--- a/tests/verilog/multi/test1.sv
+++ b/tests/verilog/multi/test1.sv
@@ -1,0 +1,9 @@
+module test;
+
+reg [`WIDTH-1:0] cnt;
+reg clk=0;
+always #1 clk = ~clk;
+
+dut u0(clk);
+
+endmodule


### PR DESCRIPTION
This PR is related to sgherbst/svinst#8.  Now that there is a new option ``--separate`` for ``svinst``, the Python interface has been updated to support that option as well.  In addition, I found a bug in the handling of files with no module definitions, so that is fixed here, as well.