### PR TITLE
Support Python 3.8, show macro definitions, explain files with syntax errors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,6 +35,6 @@ jobs:
         pip install pytest pytest-cov
         pytest --cov-report=xml --cov=svinst tests -v -r s
     - name: Upload coverage
-      uses: codecov/codecov-action@v1.0.3
+      uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage
 
-on: [push]
+on: []
 
 jobs:
   build:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install package
       run: |
-        pip install -e .
+        pip install -e . -v -v
     - name: Test with pytest while generating coverage information
       run: |
         pip install pytest pytest-cov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage
 
-on: []
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: [3.6, 3.7, 3.8]
         rust-version: [stable]
 
     runs-on: ${{ matrix.os }}
@@ -36,9 +36,19 @@ jobs:
     - name: Build binary distributions
       env:
         DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
+        PYTHON_VERSION: ${{ matrix.python-version }}
         PLAT: manylinux1_x86_64
-        PYVER: cp37-cp37m
       run: |
+        if [[ "${PYTHON_VERSION}" == "3.6" ]]; then
+            PYVER=cp36-cp36m
+        elif [[ "${PYTHON_VERSION}" == "3.7" ]]; then
+            PYVER=cp37-cp37m
+        elif [[ "${PYTHON_VERSION}" == "3.8" ]]; then
+            PYVER=cp38-cp38m
+        else
+            printf '%s\n' "Unknown Python version." >&2
+            exit 1
+        fi
         docker pull $DOCKER_IMAGE
         docker run --rm -e PLAT=$PLAT -e PYVER=$PYVER -v `pwd`:/io $DOCKER_IMAGE /io/build-manylinux-wheels.sh
     - name: Publish wheels to PyPI

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -35,22 +35,14 @@ jobs:
         python setup.py sdist
     - name: Build Python 3.7 distribution
       if: matrix.python-version == '3.7'
-      env:
-        DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
-        PLAT: manylinux1_x86_64
-        PYVER: cp37-cp37m
       run: |
-        docker pull $DOCKER_IMAGE
-        docker run --rm -e PLAT=$PLAT -e PYVER=$PYVER -v `pwd`:/io $DOCKER_IMAGE /io/build-manylinux-wheels.sh
+        docker pull quay.io/pypa/manylinux1_x86_64
+        docker run --rm -e PLAT=manylinux1_x86_64 -e PYVER=cp37-cp37m -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/build-manylinux-wheels.sh
     - name: Build Python 3.8 distribution
       if: matrix.python-version == '3.8'
-      env:
-        DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
-        PLAT: manylinux1_x86_64
-        PYVER: cp38-cp38
       run: |
-        docker pull $DOCKER_IMAGE
-        docker run --rm -e PLAT=$PLAT -e PYVER=$PYVER -v `pwd`:/io $DOCKER_IMAGE /io/build-manylinux-wheels.sh
+        docker pull quay.io/pypa/manylinux1_x86_64
+        docker run --rm -e PLAT=manylinux1_x86_64 -e PYVER=cp38-cp38 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/build-manylinux-wheels.sh
     - name: Publish wheels to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -43,10 +43,16 @@ jobs:
       run: |
         docker pull quay.io/pypa/manylinux1_x86_64
         docker run --rm -e PLAT=manylinux1_x86_64 -e PYVER=cp38-cp38 -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/build-manylinux-wheels.sh
-    - name: Publish wheels to PyPI
+    - name: Publish source to PyPI
+      if: matrix.python-version == '3.7'
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        twine upload dist/*
+    - name: Publish binaries to PyPI
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         twine upload wheelhouse/svinst*-manylinux*.whl
-        twine upload dist/*

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         rust-version: [stable]
 
     runs-on: ${{ matrix.os }}
@@ -39,12 +39,10 @@ jobs:
         PYTHON_VERSION: ${{ matrix.python-version }}
         PLAT: manylinux1_x86_64
       run: |
-        if [[ "${PYTHON_VERSION}" == "3.6" ]]; then
-            PYVER=cp36-cp36m
-        elif [[ "${PYTHON_VERSION}" == "3.7" ]]; then
+        if [[ "${PYTHON_VERSION}" == "3.7" ]]; then
             PYVER=cp37-cp37m
         elif [[ "${PYTHON_VERSION}" == "3.8" ]]; then
-            PYVER=cp38-cp38m
+            PYVER=cp38-cp38
         else
             printf '%s\n' "Unknown Python version." >&2
             exit 1

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         python setup.py sdist
     - name: Build Python 3.7 distribution
-      if: ${{ matrix.python-version == "3.7" }}
+      if: matrix.python-version == '3.7'
       env:
         DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
         PLAT: manylinux1_x86_64
@@ -43,7 +43,7 @@ jobs:
         docker pull $DOCKER_IMAGE
         docker run --rm -e PLAT=$PLAT -e PYVER=$PYVER -v `pwd`:/io $DOCKER_IMAGE /io/build-manylinux-wheels.sh
     - name: Build Python 3.8 distribution
-      if: ${{ matrix.python-version == "3.8" }}
+      if: matrix.python-version == '3.8'
       env:
         DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
         PLAT: manylinux1_x86_64

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
         rust-version: [stable]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         python setup.py sdist
     - name: Build Python 3.7 distribution
-      if: {{ matrix.python-version == "3.7" }}
+      if: ${{ matrix.python-version == "3.7" }}
       env:
         DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
         PLAT: manylinux1_x86_64
@@ -43,7 +43,7 @@ jobs:
         docker pull $DOCKER_IMAGE
         docker run --rm -e PLAT=$PLAT -e PYVER=$PYVER -v `pwd`:/io $DOCKER_IMAGE /io/build-manylinux-wheels.sh
     - name: Build Python 3.8 distribution
-      if: {{ matrix.python-version == "3.8" }}
+      if: ${{ matrix.python-version == "3.8" }}
       env:
         DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
         PLAT: manylinux1_x86_64

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.7]
         rust-version: [stable]
 
     runs-on: ${{ matrix.os }}
@@ -33,20 +33,22 @@ jobs:
     - name: Build source distribution
       run: |
         python setup.py sdist
-    - name: Build binary distributions
+    - name: Build Python 3.7 distribution
+      if: {{ matrix.python-version == "3.7" }}
       env:
         DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
-        PYTHON_VERSION: ${{ matrix.python-version }}
         PLAT: manylinux1_x86_64
+        PYVER: cp37-cp37m
       run: |
-        if [[ "${PYTHON_VERSION}" == "3.7" ]]; then
-            PYVER=cp37-cp37m
-        elif [[ "${PYTHON_VERSION}" == "3.8" ]]; then
-            PYVER=cp38-cp38
-        else
-            printf '%s\n' "Unknown Python version." >&2
-            exit 1
-        fi
+        docker pull $DOCKER_IMAGE
+        docker run --rm -e PLAT=$PLAT -e PYVER=$PYVER -v `pwd`:/io $DOCKER_IMAGE /io/build-manylinux-wheels.sh
+    - name: Build Python 3.8 distribution
+      if: {{ matrix.python-version == "3.8" }}
+      env:
+        DOCKER_IMAGE: quay.io/pypa/manylinux1_x86_64
+        PLAT: manylinux1_x86_64
+        PYVER: cp38-cp38
+      run: |
         docker pull $DOCKER_IMAGE
         docker run --rm -e PLAT=$PLAT -e PYVER=$PYVER -v `pwd`:/io $DOCKER_IMAGE /io/build-manylinux-wheels.sh
     - name: Publish wheels to PyPI

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
         rust-version: [stable]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -31,7 +31,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install package
       run: |
-        pip install -e .
+        pip install -e . -v -v
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -29,7 +29,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Install package
       run: |
-        pip install -e .
+        pip install -e . -v -v
     - name: Test with pytest
       run: |
         pip install pytest

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
         rust-version: [stable]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest]
-        python-version: [3.7]
+        python-version: [3.6, 3.7, 3.8]
         rust-version: [stable]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         rust-version: [stable]
 
     runs-on: ${{ matrix.os }}

--- a/build-manylinux-wheels.sh
+++ b/build-manylinux-wheels.sh
@@ -13,6 +13,8 @@ yum -y install libyaml libyaml-devel
 # Install Rust
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 source $HOME/.cargo/env
+rustup default 1.46.0
+rustc --version
 
 # Update pip
 "/opt/python/${PYVER}/bin/pip" install --upgrade --no-cache-dir pip

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev23'
+version = '0.1.7.dev28'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev34'
+version = '0.1.7'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.6'
+version = '0.1.7.dev1'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev18'
+version = '0.1.7.dev19'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev28'
+version = '0.1.7.dev29'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev22'
+version = '0.1.7.dev23'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev1'
+version = '0.1.7.dev18'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev32'
+version = '0.1.7.dev33'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev29'
+version = '0.1.7.dev30'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\
@@ -60,7 +60,8 @@ setup(
         ]
     },
     install_requires=[
-        'PyYAML'
+        'PyYAML',
+        'colorama'
     ],
     # configure building of svinst binary
     ext_modules=[Extension('svinst', [])],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev21'
+version = '0.1.7.dev22'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev19'
+version = '0.1.7.dev20'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev33'
+version = '0.1.7.dev34'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev20'
+version = '0.1.7.dev21'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev31'
+version = '0.1.7.dev32'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\
@@ -60,8 +60,7 @@ setup(
         ]
     },
     install_requires=[
-        'PyYAML',
-        'colorama'
+        'PyYAML'
     ],
     # configure building of svinst binary
     ext_modules=[Extension('svinst', [])],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7.dev30'
+version = '0.1.7.dev31'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/svinst/defchk.py
+++ b/svinst/defchk.py
@@ -15,7 +15,6 @@ class SVInstParsingError(Exception):
         file_list: List of files that were passed to svinst
         svinst_stderr: Output of the svinst tool to standard error (stderr)
         svinst_retcode: Return code of svinst
-        nl: Newline character to use when formatting the exception message
     """
 
     def __init__(self, error_set=None, file_list=None, svinst_stderr=None,

--- a/svinst/defchk.py
+++ b/svinst/defchk.py
@@ -11,8 +11,11 @@ class SVInstParsingError(Exception):
     """Exception raised for errors while parsing.
 
     Attributes:
-        error_list: list of tuples (index, file_name)
-        message: original raw error message
+        error_set: Set of file indices that have parsing errors (starts at zero)
+        file_list: List of files that were passed to svinst
+        svinst_stderr: Output of the svinst tool to standard error (stderr)
+        svinst_retcode: Return code of svinst
+        nl: Newline character to use when formatting the exception message
     """
 
     def __init__(self, error_set=None, file_list=None, svinst_stderr=None,

--- a/svinst/defchk.py
+++ b/svinst/defchk.py
@@ -200,12 +200,13 @@ def process_macro_defs(result):
     return retval
 
 def get_defs(files, includes=None, defines=None, ignore_include=False,
-             separate=False, show_macro_defs=False):
+             separate=False, show_macro_defs=False, explain_error=True):
     single = is_single_file(files)
 
     out = call_svinst(files=files, includes=includes, defines=defines,
                       ignore_include=ignore_include, separate=separate,
-                      show_macro_defs=show_macro_defs, full_tree=False)
+                      show_macro_defs=show_macro_defs, explain_error=explain_error,
+                      full_tree=False)
 
     retval = []
     for elem in out['files']:
@@ -289,12 +290,13 @@ def process_syntax_tree(result):
     return retval
 
 def get_syntax_tree(files, includes=None, defines=None, ignore_include=False,
-                    separate=False, show_macro_defs=False):
+                    separate=False, show_macro_defs=False, explain_error=True):
     single = is_single_file(files)
 
     out = call_svinst(files=files, includes=includes, defines=defines,
                       ignore_include=ignore_include, separate=separate,
-                      show_macro_defs=show_macro_defs, full_tree=True)
+                      show_macro_defs=show_macro_defs, explain_error=explain_error,
+                      full_tree=True)
 
     retval = [process_syntax_tree(elem['syntax_tree']) for elem in out['files']]
 

--- a/svinst/defchk.py
+++ b/svinst/defchk.py
@@ -10,7 +10,7 @@ try:
         return f'{Fore.RED}{Style.BRIGHT}{s}{Style.RESET_ALL}'
 except:
     def error_text(s):
-        return f'{s}'
+        return f'**{s}**'
 
 def is_single_file(files):
     return isinstance(files, (str, Path))

--- a/svinst/defchk.py
+++ b/svinst/defchk.py
@@ -4,13 +4,8 @@ import subprocess
 import yaml
 import sys
 
-try:
-    from colorama import Fore, Style
-    def error_text(s):
-        return f'{Fore.RED}{Style.BRIGHT}{s}{Style.RESET_ALL}'
-except:
-    def error_text(s):
-        return f'**{s}**'
+def error_text(s):
+    return f'**{s}**'
 
 def is_single_file(files):
     return isinstance(files, (str, Path))

--- a/tests/test_svinst.py
+++ b/tests/test_svinst.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 from svinst import *
 from svinst.defchk import (ModDef, ModInst, SyntaxNode, SyntaxToken,
-                           PkgDef, PkgInst, IntfDef)
+                           PkgDef, PkgInst, IntfDef, MacroDef)
 
 VLOG_DIR = Path(__file__).resolve().parent / 'verilog'
 
@@ -39,12 +39,14 @@ def test_inc():
 
 def test_def():
     defines = {'MODULE_NAME': 'module_name_from_define', 'EXTRA_INSTANCE': None}
-    result = get_defs(VLOG_DIR / 'def_test.sv', defines=defines)
+    result = get_defs(VLOG_DIR / 'def_test.sv', defines=defines, show_macro_defs=True)
     expct = [
       ModDef("def_top", [
         ModInst("module_name_from_define", "I0"),
         ModInst("module_from_ifdef", "I1")
-      ])
+      ]),
+      MacroDef('Define { identifier: "EXTRA_INSTANCE", arguments: [], text: None }'),
+      MacroDef('Define { identifier: "MODULE_NAME", arguments: [], text: Some(DefineText { text: "module_name_from_define", origin: None }) }')
     ]
     assert result == expct
 

--- a/tests/verilog/mux/mux.sv
+++ b/tests/verilog/mux/mux.sv
@@ -1,0 +1,16 @@
+`ifdef MUX1
+module mux1
+`elsif MUX2
+module mux2
+`endif
+#(
+    parameter DATA_WIDTH = 1
+)
+(
+    input sel,
+    input [(DATA_WIDTH-1):0] in0,
+    input [(DATA_WIDTH-1):0] in1,
+    output [(DATA_WIDTH-1):0] out
+);
+    assign out = sel ? in1 : in0;
+endmodule

--- a/tests/verilog/mux/mux1_define.svh
+++ b/tests/verilog/mux/mux1_define.svh
@@ -1,0 +1,1 @@
+`define MUX1

--- a/tests/verilog/mux/mux1_undef.svh
+++ b/tests/verilog/mux/mux1_undef.svh
@@ -1,0 +1,1 @@
+`undef MUX1

--- a/tests/verilog/mux/mux2_define.svh
+++ b/tests/verilog/mux/mux2_define.svh
@@ -1,0 +1,1 @@
+`define MUX2

--- a/tests/verilog/mux/mux2_undef.svh
+++ b/tests/verilog/mux/mux2_undef.svh
@@ -1,0 +1,1 @@
+`undef MUX2


### PR DESCRIPTION
## Summary

This PR addresses issues #6, #7, and #9.  It also updates the **sv-parser** version to 0.8.2.

## Details

1. Adds support for Python 3.8 by releasing a binary wheel for it (Linux and macOS) and including Python 3.8 in the regression tests suite.
2. Adds a debugging feature that shows macro definitions on a per-file basis.  To activate it, set ``show_macro_defs`` to ``True`` when running ``call_svinst``, ``get_defs``, or ``get_syntax_tree``.  At the moment, macro definitions are shown as text strings rendered by **sv-parser``.  In the future, these strings may be parsed to make the information inside more conveniently accessible.
3. When multiple files are passed to ``call_svinst``, ``get_defs``, or ``get_syntax_tree``, the tool will try to explain which files have syntax errors.  It prints the indices of files in the list that have errors (starting with ``1``), and indicates the names of those files using asterisks.  If needed, this feature can be disabled by setting  ``explain_error=False``.