### PR TITLE
Fix macro-defined instance name issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.7'
+version = '0.1.8.dev1'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 
 name = 'svinst'
-version = '0.1.8.dev1'
+version = '0.1.8'
 
 DESCRIPTION = '''\
 Python library for parsing module definitions and instantiations from SystemVerilog files\

--- a/tests/test_svinst.py
+++ b/tests/test_svinst.py
@@ -167,6 +167,13 @@ def test_mux():
     ]
     assert result == expct
 
+def test_macro_inst_name():
+    result = get_defs(VLOG_DIR / 'macro_inst_name.sv')
+    expct = [
+        ModDef("mymod", [ModInst("mysubmod", "u_mysubmod")])
+    ]
+    assert result == expct
+
 def test_error_explain():
     # expect parsing of these files to fail
     try:

--- a/tests/verilog/macro_inst_name.sv
+++ b/tests/verilog/macro_inst_name.sv
@@ -1,0 +1,16 @@
+module mymod (
+);
+
+`define MY_TOP mysubmod
+`define MY_INST u_mysubmod
+
+  `MY_TOP
+#(
+  .param1(param1),
+  .param2(param2)
+ )
+ `MY_INST (
+   .clk(clk)
+);
+
+endmodule


### PR DESCRIPTION
This small PR addresses issue #10 by upgrading the ``sv-parser`` dependency (which recently fixed the root cause of the error).  A regression test is added for this case to prevent it from occurring again.